### PR TITLE
feat: add `rm` alias to `remove` command

### DIFF
--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -36,6 +36,8 @@ func main() {
 		cmd = cmd_edit
 	case "remove":
 		cmd = cmd_remove
+	case "rm":
+		cmd = cmd_remove
 	default:
 		cmd = nil
 	}


### PR DESCRIPTION
#Add `rm` alias to `remove` command
Closes #8
