### PR TITLE
add `help` doc in commands

### DIFF
--- a/cmd/project/config.go
+++ b/cmd/project/config.go
@@ -8,6 +8,19 @@ import (
 	fc "github.com/matherique/project-manager/internal/file_config"
 )
 
+const doc_config string = `
+Usage:
+  project config                     Get all configuration
+  project config [name]              Get the configuration by name
+  project config [name] [value]      Set the configuration value
+
+Configurations avaliable:
+  editor     Editor binary name
+  scripts    Path to folder used to save projects
+
+Set or get configuration value
+`
+
 func cmd_config(a []string, c fc.FileConfig) error {
 	c.Load()
 

--- a/cmd/project/edit.go
+++ b/cmd/project/edit.go
@@ -8,6 +8,12 @@ import (
 	"github.com/matherique/project-manager/internal/project"
 )
 
+const doc_edit string = `
+Usage: project edit [name] 
+
+Open project script file to edit
+`
+
 func cmd_edit(args []string, c fc.FileConfig) error {
 	if len(args) == 0 {
 		return fmt.Errorf("missing project name")

--- a/cmd/project/fzf.go
+++ b/cmd/project/fzf.go
@@ -10,6 +10,12 @@ import (
 	"github.com/matherique/project-manager/internal/project"
 )
 
+const doc_fzf string = `
+Usage: project fzf
+
+List all project with fzf, and open if selected
+`
+
 func cmd_fzf(_ []string, c fc.FileConfig) error {
 	projects := project.All(c)
 

--- a/cmd/project/fzf.go
+++ b/cmd/project/fzf.go
@@ -29,6 +29,10 @@ func cmd_fzf(_ []string, c fc.FileConfig) error {
 		return err
 	}
 
+	if p == "" {
+		return nil
+	}
+
 	return cmd_open([]string{p}, c)
 }
 

--- a/cmd/project/help.go
+++ b/cmd/project/help.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	fc "github.com/matherique/project-manager/internal/file_config"
 )
@@ -15,13 +16,15 @@ Usage: project [command] [args]
 
 Commands:
  create   Create a new project
+ open     Start the project
  list     List all created projects
  config   List all configuration
  edit     Edit an project setup file
  remove   Remove and project
  fzf      List all created projects using fzf and execute what you choose
 
-Use 'project [command] help' for more information about the command`
-	fmt.Fprintln(os.Stdout, doc)
+Use 'project [command] help' for more information about the command
+`
+	fmt.Fprintln(os.Stdout, strings.Trim(doc, "\n"))
 	return nil
 }

--- a/cmd/project/list.go
+++ b/cmd/project/list.go
@@ -9,6 +9,12 @@ import (
 	"github.com/matherique/project-manager/internal/project"
 )
 
+const doc_list string = `
+Usage: project list|ls
+
+List all available projects
+`
+
 func cmd_list(args []string, c fc.FileConfig) error {
 	c.Load()
 

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -47,8 +47,10 @@ func main() {
 		cmd = cmd_config
 	case "list":
 		cmd = cmd_list
+		doc = doc_list
 	case "ls":
 		cmd = cmd_list
+		doc = doc_list
 	case "edit":
 		cmd = cmd_edit
 	case "remove":

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -56,6 +56,7 @@ func main() {
 		cmd = cmd_remove
 	case "fzf":
 		cmd = cmd_fzf
+		doc = doc_fzf
 	default:
 		cmd = nil
 	}

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -53,8 +53,10 @@ func main() {
 		cmd = cmd_edit
 	case "remove":
 		cmd = cmd_remove
+		doc = doc_remove
 	case "rm":
 		cmd = cmd_remove
+		doc = doc_remove
 	case "fzf":
 		cmd = cmd_fzf
 		doc = doc_fzf

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -46,6 +46,7 @@ func main() {
 		doc = doc_create
 	case "config":
 		cmd = cmd_config
+		doc = doc_config
 	case "list":
 		cmd = cmd_list
 		doc = doc_list

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	fc "github.com/matherique/project-manager/internal/file_config"
 )
@@ -72,7 +73,7 @@ func main() {
 	}
 
 	if len(os.Args) == 3 && os.Args[2] == "help" {
-		fmt.Fprintln(os.Stdout, doc)
+		fmt.Fprintln(os.Stdout, strings.Trim(doc, "\n"))
 		return
 	}
 

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -39,6 +39,7 @@ func main() {
 		doc = doc_create
 	case "open":
 		cmd = cmd_open
+		doc = doc_open
 	case "new":
 		cmd = cmd_create
 		doc = doc_create

--- a/cmd/project/main.go
+++ b/cmd/project/main.go
@@ -55,6 +55,7 @@ func main() {
 		doc = doc_list
 	case "edit":
 		cmd = cmd_edit
+		doc = doc_edit
 	case "remove":
 		cmd = cmd_remove
 		doc = doc_remove

--- a/cmd/project/open.go
+++ b/cmd/project/open.go
@@ -8,6 +8,12 @@ import (
 	"github.com/matherique/project-manager/internal/project"
 )
 
+const doc_open string = `
+Usage: project open [name] 
+
+Execute the project script
+`
+
 func cmd_open(a []string, c fc.FileConfig) error {
 	if len(a) == 0 {
 		return fmt.Errorf("missing project name")

--- a/cmd/project/remove.go
+++ b/cmd/project/remove.go
@@ -7,6 +7,12 @@ import (
 	"github.com/matherique/project-manager/internal/project"
 )
 
+const doc_remove string = `
+Usage: project remove|rm [name] 
+
+Remove the project from the list
+`
+
 func cmd_remove(args []string, c fc.FileConfig) error {
 	if len(args) == 0 {
 		return fmt.Errorf("missing project name")


### PR DESCRIPTION
- feat: add `help` doc in `fzf` command
- fix: bug when cancel fzf execution
- feat: add `help` doc in `open` command
- feat: add `help` doc in `remove` and `rm` command
- feat: add `help` doc in `list` and `ls` command
- feat: remove \n from all `help` docs
- feat: add `help` doc in `config` command
- feat: add `help` doc in `edit` command
- feat: Trim help doc in `help` command


Closes #19
